### PR TITLE
Make requiredPermissionRegistration required.

### DIFF
--- a/resources/v5/schema.json
+++ b/resources/v5/schema.json
@@ -877,7 +877,7 @@
       },
       "_rioConsumer": {
         "hidden": true,
-        "generator": ["object-with-optionals", {"explanationRequiredPermission": 0.1, "requiredPermissionRegistration": 0.5},
+        "generator": ["object-with-optionals", {"explanationRequiredPermission": 0.1},
                       "consumerKey", "explanationRequiredPermission", "requiredPermissionRegistration", "registrationStatus",
                       "rio"],
         "deps": ["programOffering/_rioExplanationRequiredPermission", "programOffering/_rioRequiredPermissionRegistration", "programOffering/_rioRegistrationStatus"]
@@ -1033,7 +1033,7 @@
       },
       "_rioConsumer": {
         "hidden": true,
-        "generator": ["object-with-optionals", {"explanationRequiredPermission": 0.1, "requiredPermissionRegistration": 0.5},
+        "generator": ["object-with-optionals", {"explanationRequiredPermission": 0.1},
                       "consumerKey", "explanationRequiredPermission", "requiredPermissionRegistration", "registrationStatus",
                       "rio"],
         "deps": ["courseOffering/_rioExplanationRequiredPermission", "courseOffering/_rioRequiredPermissionRegistration", "courseOffering/_rioRegistrationStatus"]


### PR DESCRIPTION
The field requiredPermissionRegistration in the rio-consumer struct should be required, 
since toestemmingVereistVoorAanmelding is required in the xsd schema.
